### PR TITLE
Add native browser input support and improve server thread safety

### DIFF
--- a/src/client/core/browser/client.cpp
+++ b/src/client/core/browser/client.cpp
@@ -154,6 +154,22 @@ void BrowserClient::OnPaint(CefRefPtr<CefBrowser> /*browser*/,
     manager_.OnPaint(browserId_, buffer, width, height, dirty_rects.data(), dirty_rects.size());
 }
 
+bool BrowserClient::StartDragging(CefRefPtr<CefBrowser> browser,
+                                  CefRefPtr<CefDragData> drag_data,
+                                  DragOperationsMask allowed_ops,
+                                  int x,
+                                  int y)
+{
+    CEF_REQUIRE_UI_THREAD();
+    return manager_.StartDragging(browserId_, browser, drag_data, allowed_ops, x, y);
+}
+
+void BrowserClient::UpdateDragCursor(CefRefPtr<CefBrowser> /*browser*/, DragOperation operation)
+{
+    CEF_REQUIRE_UI_THREAD();
+    manager_.UpdateDragCursor(browserId_, operation);
+}
+
 bool BrowserClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> /*browser*/,
                                              CefRefPtr<CefFrame> /*frame*/,
                                              CefProcessId /*source_process*/,

--- a/src/client/core/browser/client.hpp
+++ b/src/client/core/browser/client.hpp
@@ -44,6 +44,12 @@ public:
         const RectList& dirtyRects,
         const void* buffer,
         int width, int height) override;
+    bool StartDragging(CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefDragData> drag_data,
+        DragOperationsMask allowed_ops,
+        int x,
+        int y) override;
+    void UpdateDragCursor(CefRefPtr<CefBrowser> browser, DragOperation operation) override;
 
     // CefDisplayHandler overrides
     bool OnCursorChange(CefRefPtr<CefBrowser> browser,

--- a/src/client/core/browser/manager.cpp
+++ b/src/client/core/browser/manager.cpp
@@ -1,6 +1,7 @@
 #include "manager.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <filesystem>
 
 #include <game_sa/CPlayerPed.h>
@@ -53,6 +54,21 @@ static uint32_t GetCefEventFlags()
         flags |= EVENTFLAG_CAPS_LOCK_ON;
     if (GetKeyState(VK_NUMLOCK) & 1)
         flags |= EVENTFLAG_NUM_LOCK_ON;
+    return flags;
+}
+
+static uint32_t GetCefMouseEventFlags(WPARAM wParam)
+{
+    uint32_t flags = GetCefEventFlags();
+    flags &= ~(EVENTFLAG_LEFT_MOUSE_BUTTON | EVENTFLAG_RIGHT_MOUSE_BUTTON | EVENTFLAG_MIDDLE_MOUSE_BUTTON);
+
+    const WORD keyState = GET_KEYSTATE_WPARAM(wParam);
+    if ((keyState & MK_LBUTTON) != 0)
+        flags |= EVENTFLAG_LEFT_MOUSE_BUTTON;
+    if ((keyState & MK_RBUTTON) != 0)
+        flags |= EVENTFLAG_RIGHT_MOUSE_BUTTON;
+    if ((keyState & MK_MBUTTON) != 0)
+        flags |= EVENTFLAG_MIDDLE_MOUSE_BUTTON;
     return flags;
 }
 
@@ -761,6 +777,7 @@ void BrowserManager::SetBrowserVisible(int id, bool visible)
 
     if (!visible)
     {
+        CancelDrag(id);
         ClearPendingPaint(id);
 
         if (focusedBrowserId_ == id)
@@ -778,6 +795,7 @@ void BrowserManager::DestroyBrowser(int id)
 
     player_stats_poll_.erase(id);
     pending_.erase(id);
+    CancelDrag(id);
 
     auto it = browsers_.find(id);
     if (it == browsers_.end())
@@ -1382,6 +1400,7 @@ void BrowserManager::FocusBrowser(int browserId, bool focus)
         if (focusedBrowserId_ != browserId)
             return;
 
+        CancelDrag(browserId);
         focusedBrowserId_ = -1;
         instance_to_change->view.SetFocused(false);
 
@@ -1452,6 +1471,8 @@ void BrowserManager::OnGameFocusLost()
         CefPostTask(TID_UI, base::BindOnce(&BrowserManager::OnGameFocusLost, base::Unretained(this)));
         return;
     }
+
+    CancelDrag();
 
     auto* focused = GetFocusedBrowser();
     if (!focused || !focused->browser)
@@ -1670,6 +1691,169 @@ void BrowserManager::OnDeviceReset(IDirect3DDevice9* device)
     isCefUpdatesPaused_ = false;
 }
 
+bool BrowserManager::StartDragging(int browserId,
+                                   CefRefPtr<CefBrowser> browser,
+                                   CefRefPtr<CefDragData> dragData,
+                                   cef_drag_operations_mask_t allowedOps,
+                                   int x,
+                                   int y)
+{
+    CEF_REQUIRE_UI_THREAD();
+    (void)x;
+    (void)y;
+    if (!browser || !dragData || allowedOps == DRAG_OPERATION_NONE)
+        return false;
+
+    auto targetData = dragData->Clone();
+    if (!targetData)
+        return false;
+
+    // DragTargetDragEnter rejects file contents originating from StartDragging.
+    // The metadata and file names remain available after this call.
+    targetData->ResetFileContents();
+    CancelDrag();
+
+    drag_.browserId = browserId;
+    drag_.browser = std::move(browser);
+    drag_.data = std::move(targetData);
+    drag_.allowedOps = allowedOps;
+    drag_.currentOperation = DRAG_OPERATION_NONE;
+    drag_.lastX = last_mouse_x_.load();
+    drag_.lastY = last_mouse_y_.load();
+    drag_.entered = false;
+    drag_active_.store(true, std::memory_order_release);
+    return true;
+}
+
+void BrowserManager::UpdateDragCursor(int browserId, cef_drag_operations_mask_t operation)
+{
+    CEF_REQUIRE_UI_THREAD();
+    if (drag_.browserId == browserId && drag_.browser)
+        drag_.currentOperation = operation;
+}
+
+bool BrowserManager::HandleDragMouseMove(const CefMouseEvent& event)
+{
+    if (!drag_active_.load(std::memory_order_acquire))
+        return false;
+
+    CefPostTask(TID_UI, base::BindOnce(&BrowserManager::HandleDragMouseMoveOnUi,
+        base::Unretained(this), event));
+    return true;
+}
+
+void BrowserManager::HandleDragMouseMoveOnUi(CefMouseEvent event)
+{
+    CEF_REQUIRE_UI_THREAD();
+    if (!drag_.browser || !drag_.data)
+        return;
+
+    drag_.lastX = event.x;
+    drag_.lastY = event.y;
+
+    auto host = drag_.browser->GetHost();
+    if (!host)
+    {
+        CancelDrag();
+        return;
+    }
+
+    if (!drag_.entered)
+    {
+        host->DragTargetDragEnter(drag_.data, event, drag_.allowedOps);
+        drag_.entered = true;
+    }
+    host->DragTargetDragOver(event, drag_.allowedOps);
+}
+
+bool BrowserManager::HandleDragMouseUp(const CefMouseEvent& event)
+{
+    if (!drag_active_.exchange(false, std::memory_order_acq_rel))
+        return false;
+
+    CefPostTask(TID_UI, base::BindOnce(&BrowserManager::HandleDragMouseUpOnUi,
+        base::Unretained(this), event));
+    return true;
+}
+
+void BrowserManager::HandleDragMouseUpOnUi(CefMouseEvent event)
+{
+    CEF_REQUIRE_UI_THREAD();
+    if (!drag_.browser || !drag_.data)
+        return;
+
+    auto host = drag_.browser->GetHost();
+    if (!host)
+    {
+        drag_ = DragState{};
+        return;
+    }
+
+    if (!drag_.entered)
+        host->DragTargetDragEnter(drag_.data, event, drag_.allowedOps);
+    host->DragTargetDragOver(event, drag_.allowedOps);
+    host->DragTargetDrop(event);
+
+    DragState completed = drag_;
+    completed.lastX = event.x;
+    completed.lastY = event.y;
+    drag_ = DragState{};
+    host->DragSourceEndedAt(event.x, event.y, completed.currentOperation);
+    host->DragSourceSystemDragEnded();
+}
+
+void BrowserManager::CancelDrag(int browserId)
+{
+    if (!CefCurrentlyOn(TID_UI))
+    {
+        drag_active_.store(false, std::memory_order_release);
+        CefPostTask(TID_UI, base::BindOnce(&BrowserManager::CancelDrag,
+            base::Unretained(this), browserId));
+        return;
+    }
+
+    if (!drag_.browser || (browserId != -1 && drag_.browserId != browserId))
+        return;
+
+    DragState cancelled = drag_;
+    drag_ = DragState{};
+    drag_active_.store(false, std::memory_order_release);
+
+    auto host = cancelled.browser->GetHost();
+    if (!host)
+        return;
+
+    if (cancelled.entered)
+        host->DragTargetDragLeave();
+    host->DragSourceEndedAt(cancelled.lastX, cancelled.lastY, DRAG_OPERATION_NONE);
+    host->DragSourceSystemDragEnded();
+}
+
+int BrowserManager::BeginMouseClick(MouseClickTracker& tracker, int browserId, int x, int y, bool explicitDoubleClick)
+{
+    const uint32_t now = static_cast<uint32_t>(GetMessageTime());
+    const uint32_t elapsed = now - tracker.lastDownTime;
+    const int maxX = std::max(1, GetSystemMetrics(SM_CXDOUBLECLK) / 2);
+    const int maxY = std::max(1, GetSystemMetrics(SM_CYDOUBLECLK) / 2);
+    const bool sameBrowser = tracker.browserId == browserId;
+    const bool closeInTime = tracker.lastDownTime != 0 && elapsed <= GetDoubleClickTime();
+    const bool closeInSpace = std::abs(x - tracker.lastDownX) <= maxX && std::abs(y - tracker.lastDownY) <= maxY;
+
+    if (explicitDoubleClick && sameBrowser)
+        tracker.sequenceCount = 2;
+    else if (sameBrowser && closeInTime && closeInSpace)
+        tracker.sequenceCount = std::min(tracker.sequenceCount + 1, 3);
+    else
+        tracker.sequenceCount = 1;
+
+    tracker.lastDownTime = now;
+    tracker.lastDownX = x;
+    tracker.lastDownY = y;
+    tracker.activeCount = tracker.sequenceCount;
+    tracker.browserId = browserId;
+    return tracker.activeCount;
+}
+
 LRESULT BrowserManager::OnWndProcMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     bool native_ui_message_consumed = false;
@@ -1712,6 +1896,11 @@ LRESULT BrowserManager::OnWndProcMessage(HWND hwnd, UINT msg, WPARAM wParam, LPA
         }
     }
 
+    if (msg == WM_CAPTURECHANGED || msg == WM_CANCELMODE || msg == WM_KILLFOCUS)
+    {
+        CancelDrag();
+    }
+
     auto* focused_inst = GetFocusedBrowser();
     if (!focused_inst || !focused_inst->browser)
         return false;
@@ -1725,25 +1914,59 @@ LRESULT BrowserManager::OnWndProcMessage(HWND hwnd, UINT msg, WPARAM wParam, LPA
         case WM_MOUSEMOVE:
         case WM_LBUTTONDOWN:
         case WM_LBUTTONUP:
+        case WM_LBUTTONDBLCLK:
         case WM_RBUTTONDOWN:
         case WM_RBUTTONUP:
+        case WM_RBUTTONDBLCLK:
+        case WM_MBUTTONDOWN:
+        case WM_MBUTTONUP:
+        case WM_MBUTTONDBLCLK:
         case WM_MOUSEWHEEL:
         {
+            POINT point{ GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            if (msg == WM_MOUSEWHEEL)
+                ScreenToClient(hwnd, &point);
+
             CefMouseEvent evt;
-            evt.x = GET_X_LPARAM(lParam);
-            evt.y = GET_Y_LPARAM(lParam);
-            evt.modifiers = GetCefEventFlags();
+            evt.x = point.x;
+            evt.y = point.y;
+            evt.modifiers = GetCefMouseEventFlags(wParam);
+            last_mouse_x_.store(evt.x);
+            last_mouse_y_.store(evt.y);
 
             if (msg == WM_MOUSEMOVE)
+            {
+                if (HandleDragMouseMove(evt))
+                    return true;
                 host->SendMouseMoveEvent(evt, false);
-            else if (msg == WM_LBUTTONDOWN)
-                host->SendMouseClickEvent(evt, MBT_LEFT, false, 1);
+            }
+            else if (msg == WM_LBUTTONDOWN || msg == WM_LBUTTONDBLCLK)
+            {
+                const int clickCount = BeginMouseClick(left_click_, focused_inst->id, evt.x, evt.y, msg == WM_LBUTTONDBLCLK);
+                host->SendMouseClickEvent(evt, MBT_LEFT, false, clickCount);
+                SetCapture(hwnd);
+            }
             else if (msg == WM_LBUTTONUP)
-                host->SendMouseClickEvent(evt, MBT_LEFT, true, 1);
-            else if (msg == WM_RBUTTONDOWN)
-                host->SendMouseClickEvent(evt, MBT_RIGHT, false, 1);
+            {
+                if (!HandleDragMouseUp(evt))
+                    host->SendMouseClickEvent(evt, MBT_LEFT, true, left_click_.activeCount);
+                if (GetCapture() == hwnd)
+                    ReleaseCapture();
+            }
+            else if (msg == WM_RBUTTONDOWN || msg == WM_RBUTTONDBLCLK)
+            {
+                const int clickCount = BeginMouseClick(right_click_, focused_inst->id, evt.x, evt.y, msg == WM_RBUTTONDBLCLK);
+                host->SendMouseClickEvent(evt, MBT_RIGHT, false, clickCount);
+            }
             else if (msg == WM_RBUTTONUP)
-                host->SendMouseClickEvent(evt, MBT_RIGHT, true, 1);
+                host->SendMouseClickEvent(evt, MBT_RIGHT, true, right_click_.activeCount);
+            else if (msg == WM_MBUTTONDOWN || msg == WM_MBUTTONDBLCLK)
+            {
+                const int clickCount = BeginMouseClick(middle_click_, focused_inst->id, evt.x, evt.y, msg == WM_MBUTTONDBLCLK);
+                host->SendMouseClickEvent(evt, MBT_MIDDLE, false, clickCount);
+            }
+            else if (msg == WM_MBUTTONUP)
+                host->SendMouseClickEvent(evt, MBT_MIDDLE, true, middle_click_.activeCount);
             else if (msg == WM_MOUSEWHEEL)
                 host->SendMouseWheelEvent(evt, 0, GET_WHEEL_DELTA_WPARAM(wParam));
 

--- a/src/client/core/browser/manager.hpp
+++ b/src/client/core/browser/manager.hpp
@@ -4,6 +4,7 @@
 #include <bitset>
 #include <functional>
 #include <memory>
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 
@@ -166,6 +167,13 @@ public:
     void OnBrowserCreated(int id, CefRefPtr<CefBrowser> browser);
     void OnBrowserClosed(int id);
     void OnPaint(int id, const void* buffer, int w, int h, const cef_rect_t* dirtyRects, size_t dirtyRectCount);
+    bool StartDragging(int browserId,
+        CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefDragData> dragData,
+        cef_drag_operations_mask_t allowedOps,
+        int x,
+        int y);
+    void UpdateDragCursor(int browserId, cef_drag_operations_mask_t operation);
 
     void RequestTextureClear(int id);
 
@@ -214,6 +222,23 @@ private:
     void ClearPendingPaint(int id);
     void SendExternalBeginFrames();
     void DispatchExternalBeginFramesOnUi();
+    bool HandleDragMouseMove(const CefMouseEvent& event);
+    bool HandleDragMouseUp(const CefMouseEvent& event);
+    void HandleDragMouseMoveOnUi(CefMouseEvent event);
+    void HandleDragMouseUpOnUi(CefMouseEvent event);
+    void CancelDrag(int browserId = -1);
+
+    struct MouseClickTracker
+    {
+        uint32_t lastDownTime = 0;
+        int lastDownX = 0;
+        int lastDownY = 0;
+        int sequenceCount = 0;
+        int activeCount = 1;
+        int browserId = -1;
+    };
+
+    int BeginMouseClick(MouseClickTracker& tracker, int browserId, int x, int y, bool explicitDoubleClick);
 
 private:
     bool initialized_ = false;
@@ -241,6 +266,26 @@ private:
 
     std::unordered_map<int, PendingPaint> pending_;
     std::atomic<bool> begin_frame_task_pending_{false};
+
+    struct DragState
+    {
+        int browserId = -1;
+        CefRefPtr<CefBrowser> browser;
+        CefRefPtr<CefDragData> data;
+        cef_drag_operations_mask_t allowedOps = DRAG_OPERATION_NONE;
+        cef_drag_operations_mask_t currentOperation = DRAG_OPERATION_NONE;
+        int lastX = 0;
+        int lastY = 0;
+        bool entered = false;
+    };
+
+    DragState drag_;
+    std::atomic<bool> drag_active_{false};
+    std::atomic<int> last_mouse_x_{0};
+    std::atomic<int> last_mouse_y_{0};
+    MouseClickTracker left_click_;
+    MouseClickTracker right_click_;
+    MouseClickTracker middle_click_;
 
     // Keyboard capture / filtering (client -> server)
     bool key_capture_enabled_ = false;

--- a/src/server/common/bridge.hpp
+++ b/src/server/common/bridge.hpp
@@ -40,4 +40,8 @@ public:
     virtual std::string GetPlayerAddressIp(int playerid) = 0;
     virtual void KickPlayer(int playerid) = 0;
     virtual bool IsPlayerNpcBot(int playerid) = 0;
+
+    // Called on the server thread before the Pawn component is released.
+    // Bridges without a separately owned Pawn runtime need no action.
+    virtual void InvalidatePawn() {}
 };

--- a/src/server/common/network.cpp
+++ b/src/server/common/network.cpp
@@ -52,15 +52,23 @@ void NetworkServer::SendTo(const asio::ip::udp::endpoint& addr, const char* data
         return;
 
     auto send_buffer = std::make_shared<std::vector<char>>(data, data + length);
-    socket_.async_send_to(asio::buffer(*send_buffer),
-        addr,
-        [send_buffer](std::error_code ec, std::size_t)
-        {
-            if (ec && ec != asio::error::operation_aborted)
-            {
-                LOG_ERROR("[Network] Async send error: %s", ec.message().c_str());
-            }
-        });
+	// Pawn natives may flush KCP from the open.mp thread. Keep every operation
+	// on the shared UDP socket serialized by its single ASIO io_context thread.
+	asio::dispatch(io_context_, [this, addr, send_buffer]()
+	{
+		if (!running_)
+			return;
+
+		socket_.async_send_to(asio::buffer(*send_buffer),
+			addr,
+			[send_buffer](std::error_code ec, std::size_t)
+			{
+				if (ec && ec != asio::error::operation_aborted)
+				{
+					LOG_ERROR("[Network] Async send error: %s", ec.message().c_str());
+				}
+			});
+	});
 }
 
 void NetworkServer::DoReceive()

--- a/src/server/common/plugin.cpp
+++ b/src/server/common/plugin.cpp
@@ -94,19 +94,26 @@ void CefPlugin::Shutdown()
 
 	running_ = false;
 
-    if (network_server_) {
-        network_server_->Stop();
-    }
+	io_context_.stop();
 
-    if (security_) {
-        security_->Shutdown();
-        security_.reset();
-    }
+	if (network_thread_.joinable()) {
+		network_thread_.join();
+	}
 
-    io_context_.stop();
+	// ASIO owns NetworkServer and SecurityManager callbacks. Destroy/cancel
+	// them only after the io_context thread can no longer be executing one.
+	if (network_server_) {
+		network_server_->Stop();
+	}
 
-    if (network_thread_.joinable()) {
-        network_thread_.join();
+	if (security_) {
+		security_->Shutdown();
+		security_.reset();
+	}
+
+    {
+        std::lock_guard<std::mutex> lock(main_thread_tasks_mutex_);
+        main_thread_tasks_.clear();
     }
 
     network_server_.reset();
@@ -129,7 +136,10 @@ void CefPlugin::OnPlayerConnect(int playerid)
         return;
     }
 
-    sessions_->RegisterPlayer(playerid);
+	// Read open.mp player data only from this server-thread callback. The ASIO
+	// handshake uses the immutable snapshot stored in NetworkSession.
+	const std::string officialIp = bridge_->GetPlayerAddressIp(playerid);
+	sessions_->RegisterPlayer(playerid, officialIp);
     player_ui_states_[playerid] = PlayerUiState{};
     LOG_DEBUG("OnPlayerConnect: player %d registered", playerid);
 }
@@ -139,12 +149,6 @@ void CefPlugin::OnPlayerClientInit(int playerid)
     if (!bridge_ || !running_)
         return;
 
-    if (bridge_->IsPlayerNpcBot(playerid))
-    {
-        LOG_DEBUG("OnPlayerClientInit: player %d is NPC -> ignored", playerid);
-        return;
-    }
-
     auto session = sessions_->GetSession(playerid);
     if (!session)
     {
@@ -152,7 +156,7 @@ void CefPlugin::OnPlayerClientInit(int playerid)
         return;
     }
 
-    if (session->handshake_complete && !session->cef_init_notified)
+    if (session->handshake_complete && session->cef_init_state.load() == CefInitState::Pending)
     {
         LOG_DEBUG("Player %d client init: handshake already complete -> OnCefInitialize(true)", playerid);
         NotifyCefInitialize(session, true, CEF_INIT_OK, "");
@@ -165,19 +169,21 @@ void CefPlugin::OnPlayerClientInit(int playerid)
 	{
 	    return;
 	}
+	const uint64_t epoch = session->epoch.load();
+	const std::weak_ptr<NetworkSession> weakSession = session;
 
     auto timer = std::make_shared<asio::steady_timer>(io_context_);
     timer->expires_after(std::chrono::seconds(10));
-    timer->async_wait([this, playerid, timer](const std::error_code& error_code)
+	timer->async_wait([this, playerid, weakSession, epoch, timer](const std::error_code& error_code)
     {
         if (error_code || !running_ || !bridge_)
             return;
 
-        auto session = sessions_->GetSession(playerid);
-        if (!session)
+		auto session = weakSession.lock();
+		if (!IsSessionCurrent(session, epoch))
             return;
 
-        if (!session->handshake_complete && !session->cef_init_notified)
+		if (!session->handshake_complete && session->cef_init_state.load() == CefInitState::Pending)
         {
             LOG_DEBUG("Player %d: handshake timeout -> OnCefInitialize(false)", playerid);
             NotifyCefInitialize(session, false, CEF_INIT_TIMEOUT, "CEF handshake timeout");
@@ -188,9 +194,6 @@ void CefPlugin::OnPlayerClientInit(int playerid)
 void CefPlugin::OnPlayerDisconnect(int playerid)
 {
     if (!bridge_)
-        return;
-
-    if (bridge_->IsPlayerNpcBot(playerid))
         return;
 
     resource_download_dialogs_.AbortDownload(*bridge_, playerid);
@@ -212,20 +215,45 @@ void CefPlugin::SetSpawnScreenState(int playerid, bool visible)
     player_ui_states_[playerid].spawnScreenVisible = visible;
 }
 
+void CefPlugin::InvalidatePawnBridge()
+{
+	{
+		std::lock_guard<std::mutex> lock(main_thread_tasks_mutex_);
+		main_thread_tasks_.clear();
+	}
+
+	if (bridge_)
+		bridge_->InvalidatePawn();
+}
+
 void CefPlugin::OnPacketReceived(const asio::ip::udp::endpoint& from, const char* data, int len)
 {
     if (!data || len <= 0)
         return;
 
 	auto network_session = sessions_->GetSessionFromAddress(from);
-	if (network_session && network_session->handshake_status == HandshakeStatus::CONNECTED && network_session->kcp_instance) {
+	bool receivedKcpPacket = false;
+	bool awaitingHandshakeFinalize = false;
+	if (network_session)
+	{
 		{
 			std::lock_guard<std::mutex> lock(network_session->kcp_mutex);
-			ikcp_input(network_session->kcp_instance, data, len);
+			if (network_session->handshake_status == HandshakeStatus::CONNECTED && network_session->kcp_instance)
+			{
+				ikcp_input(network_session->kcp_instance, data, len);
+				receivedKcpPacket = true;
+			}
+			else
+			{
+				awaitingHandshakeFinalize = network_session->handshake_status == HandshakeStatus::CHALLENGED;
+			}
 		}
 
+		if (receivedKcpPacket)
+		{
 		HandleKcpInput(network_session);
 		return;
+		}
 	}
 
     const auto packet_type = static_cast<PacketType>(static_cast<uint8_t>(data[0]));
@@ -243,7 +271,7 @@ void CefPlugin::OnPacketReceived(const asio::ip::udp::endpoint& from, const char
             return;
         }
     }
-    else if (network_session->handshake_status == HandshakeStatus::CHALLENGED)
+	else if (awaitingHandshakeFinalize)
     {
         if (packet_type != PacketType::HandshakeFinalize)
             return;
@@ -285,7 +313,7 @@ void CefPlugin::OnPacketReceived(const asio::ip::udp::endpoint& from, const char
 			break;
 		}
 		case PacketType::HandshakeFinalize:
-			if (network_session && network_session->handshake_status == HandshakeStatus::CHALLENGED) {
+			if (network_session && awaitingHandshakeFinalize) {
 				HandleHandshakeFinalize(from, std::get<HandshakeFinalizePacket>(packet.payload), network_session);
 			}
 
@@ -297,8 +325,8 @@ void CefPlugin::OnPacketReceived(const asio::ip::udp::endpoint& from, const char
 
 void CefPlugin::HandleRequestJoin(const asio::ip::udp::endpoint& from, const RequestJoinPacket& join_packet)
 {
-    if (!bridge_ || !running_)
-        return;
+	if (!running_)
+		return;
 
     const int playerid = join_packet.playerid;
     const std::string from_ip = from.address().to_string();
@@ -317,13 +345,7 @@ void CefPlugin::HandleRequestJoin(const asio::ip::udp::endpoint& from, const Req
         return;
     }
 
-    if (bridge_->IsPlayerNpcBot(playerid))
-    {
-        LOG_DEBUG("RequestJoin refused: pid=%d is NPC (from %s:%d)", playerid, from_ip.c_str(), from_port);
-        return;
-    }
-
-    const std::string official_ip = bridge_->GetPlayerAddressIp(playerid);
+	const std::string official_ip = session->official_ip;
 
     LOG_INFO("RequestJoin pid=%d from=%s:%d official=%s", playerid, from_ip.c_str(), from_port, official_ip.c_str());
 
@@ -335,8 +357,8 @@ void CefPlugin::HandleRequestJoin(const asio::ip::udp::endpoint& from, const Req
 
     const uint32_t clientVersion = join_packet.client_version;
     const uint32_t serverVersion = PLUGIN_VERSION_U32;
-    if (clientVersion != serverVersion)
-    {
+	if (clientVersion != serverVersion)
+	{
         JoinResponsePacket reject;
         reject.accepted = false;
         reject.kcp_conv_id = 0;
@@ -353,58 +375,69 @@ void CefPlugin::HandleRequestJoin(const asio::ip::udp::endpoint& from, const Req
 
         SendRawPacketToEndpoint(from, PacketType::JoinResponse, reject);
 
-        if (session->handshake_status != HandshakeStatus::CONNECTED)
-        {
-            session->handshake_status = HandshakeStatus::NONE;
-            session->handshake_complete = false;
-            NotifyCefInitialize(session, false, CEF_INIT_VERSION_MISMATCH, reject.message);
-        }
+		HandshakeStatus status;
+		{
+			std::lock_guard<std::mutex> lock(session->kcp_mutex);
+			status = session->handshake_status;
+		}
+
+		if (status != HandshakeStatus::CONNECTED && sessions_->ResetPlayerTransport(playerid, session))
+		{
+			NotifyCefInitialize(session, false, CEF_INIT_VERSION_MISMATCH, reject.message);
+		}
 
         return;
     }
 
-    if (session->handshake_status == HandshakeStatus::CONNECTED)
-    {
-        if (session->address == from)
-        {
-            LOG_DEBUG("RequestJoin ignored: pid=%d already CONNECTED on the same endpoint", playerid);
-            return;
+	HandshakeStatus previousStatus;
+	asio::ip::udp::endpoint previousAddress;
+	{
+		std::lock_guard<std::mutex> lock(session->kcp_mutex);
+		previousStatus = session->handshake_status;
+		previousAddress = session->address;
+	}
+
+	if (previousStatus == HandshakeStatus::CONNECTED)
+	{
+		if (previousAddress == from)
+		{
+			LOG_DEBUG("RequestJoin ignored: pid=%d already CONNECTED on the same endpoint", playerid);
+			return;
         }
 
-        LOG_INFO("RequestJoin rejoin: pid=%d endpoint changed from %s:%d to %s:%d -> resetting CEF transport",
-            playerid,
-            session->address.address().to_string().c_str(),
-            static_cast<int>(session->address.port()),
-            from_ip.c_str(),
-            from_port);
+		LOG_INFO("RequestJoin rejoin: pid=%d endpoint changed from %s:%d to %s:%d -> resetting CEF transport",
+			playerid,
+			previousAddress.address().to_string().c_str(),
+			static_cast<int>(previousAddress.port()),
+			from_ip.c_str(),
+			from_port);
+	}
+	else if (previousStatus == HandshakeStatus::CHALLENGED && previousAddress != from)
+	{
+		LOG_DEBUG("RequestJoin reattempt: pid=%d endpoint changed before finalize from %s:%d to %s:%d",
+			playerid,
+			previousAddress.address().to_string().c_str(),
+			static_cast<int>(previousAddress.port()),
+			from_ip.c_str(),
+			from_port);
+	}
 
-        sessions_->ResetPlayerTransport(playerid);
-        session = sessions_->GetSession(playerid);
-        if (!session)
-            return;
-    }
-    else if (session->handshake_status == HandshakeStatus::CHALLENGED && session->address != from)
-    {
-        LOG_DEBUG("RequestJoin reattempt: pid=%d endpoint changed before finalize from %s:%d to %s:%d",
-            playerid,
-            session->address.address().to_string().c_str(),
-            static_cast<int>(session->address.port()),
-            from_ip.c_str(),
-            from_port);
+	// Every accepted join starts a new transport generation. This invalidates
+	// callbacks already queued by a previous endpoint/handshake.
+	if (!sessions_->ResetPlayerTransport(playerid, session))
+		return;
 
-        sessions_->ResetPlayerTransport(playerid);
-        session = sessions_->GetSession(playerid);
-        if (!session)
-            return;
-    }
+	{
+		std::lock_guard<std::mutex> lock(session->kcp_mutex);
+		session->address = from;
+		session->handshake_status = HandshakeStatus::CHALLENGED;
+	}
 
-    session->address = from;
-    session->handshake_status = HandshakeStatus::CHALLENGED;
-    session->handshake_complete = false;
-    session->cef_init_notified = false;
-    session->cef_success = false;
-    session->cef_init_timer_started = false;
-    sessions_->MapAddressToPlayer(playerid, from);
+	if (!sessions_->MapAddressToPlayer(playerid, session, from))
+	{
+		session->Reset();
+		return;
+	}
 
     HandshakeChallengePacket response;
     response.cookie = security_->GenerateCookie(from);
@@ -417,39 +450,42 @@ void CefPlugin::HandleHandshakeFinalize(const asio::ip::udp::endpoint& from,
 	const HandshakeFinalizePacket& finalize_packet, 
 	std::shared_ptr<NetworkSession> session)
 {
-    if (!session || !bridge_ || !running_)
-        return;
+	if (!session || !running_)
+		return;
 
-    if (session->address != from)
-    {
+	const uint64_t epoch = session->epoch.load();
+	if (!IsSessionCurrent(session, epoch))
+		return;
+
+	bool validChallenge = false;
+	{
+		std::lock_guard<std::mutex> lock(session->kcp_mutex);
+		validChallenge = session->handshake_status == HandshakeStatus::CHALLENGED && session->address == from;
+	}
+
+	if (!validChallenge)
+	{
         std::string from_ip = from.address().to_string();
         LOG_WARN("HandshakeFinalize dropped: endpoint changed pid=%d (from %s:%d)", session->playerid, from_ip.c_str(), (int)from.port());
         return;
     }
 
-    if (!security_->ValidateCookie(from, finalize_packet.cookie))
-    {
-        LOG_WARN("HandshakeFinalize failed: invalid cookie pid=%d", session->playerid);
-        session->handshake_status = HandshakeStatus::NONE;
-        session->handshake_complete = false;
-
-        NotifyCefInitialize(session, false, CEF_INIT_HANDSHAKE_FAILED, "Handshake failed: invalid cookie");
+	if (!security_->ValidateCookie(from, finalize_packet.cookie))
+	{
+		LOG_WARN("HandshakeFinalize failed: invalid cookie pid=%d", session->playerid);
+		if (sessions_->ResetPlayerTransport(session->playerid, session))
+			NotifyCefInitialize(session, false, CEF_INIT_HANDSHAKE_FAILED, "Handshake failed: invalid cookie");
         return;
     }
 
     auto session_keys = security_->FinalizeKeyExchange(session->playerid, finalize_packet.client_public_key);
-    if (!session_keys)
-    {
-        LOG_WARN("HandshakeFinalize failed: key exchange pid=%d", session->playerid);
-        session->handshake_status = HandshakeStatus::NONE;
-        session->handshake_complete = false;
-
-        NotifyCefInitialize(session, false, CEF_INIT_HANDSHAKE_FAILED, "Handshake failed: key exchange");
+	if (!session_keys)
+	{
+		LOG_WARN("HandshakeFinalize failed: key exchange pid=%d", session->playerid);
+		if (sessions_->ResetPlayerTransport(session->playerid, session))
+			NotifyCefInitialize(session, false, CEF_INIT_HANDSHAKE_FAILED, "Handshake failed: key exchange");
         return;
     }
-
-	session->rx_key = std::move(session_keys->rx);
-	session->tx_key = std::move(session_keys->tx);
 
 	JoinResponsePacket join_response;
 	join_response.accepted = true;
@@ -464,21 +500,55 @@ void CefPlugin::HandleHandshakeFinalize(const asio::ip::udp::endpoint& from,
 		join_response.manifest_json = manifest.dump();
 	}
 
+	if (!IsSessionCurrent(session, epoch))
+		return;
+
+	bool transportCreated = false;
+	{
+		std::lock_guard<std::mutex> lock(session->kcp_mutex);
+		if (session->epoch.load() == epoch &&
+			session->handshake_status == HandshakeStatus::CHALLENGED &&
+			session->address == from)
+		{
+			session->rx_key = std::move(session_keys->rx);
+			session->tx_key = std::move(session_keys->tx);
+			session->kcp_instance = ikcp_create(session->playerid, session.get());
+			if (session->kcp_instance)
+			{
+				session->kcp_instance->output = kcp_output_callback;
+				ikcp_nodelay(session->kcp_instance, 1, 10, 2, 1);
+				ikcp_wndsize(session->kcp_instance, 256, 256);
+				session->handshake_status = HandshakeStatus::CONNECTED;
+				transportCreated = true;
+			}
+		}
+	}
+
+	if (!transportCreated)
+	{
+		if (sessions_->ResetPlayerTransport(session->playerid, session))
+			NotifyCefInitialize(session, false, CEF_INIT_HANDSHAKE_FAILED, "Handshake failed: transport allocation");
+		return;
+	}
+
+	if (!IsSessionCurrent(session, epoch))
+	{
+		session->Reset();
+		return;
+	}
+
 	SendRawPacketToEndpoint(from, PacketType::JoinResponse, join_response);
-
-	session->kcp_instance = ikcp_create(session->playerid, session.get());
-	session->kcp_instance->output = kcp_output_callback;
-
-	ikcp_nodelay(session->kcp_instance, 1, 10, 2, 1);
-	ikcp_wndsize(session->kcp_instance, 256, 256);
-
-	session->handshake_status = HandshakeStatus::CONNECTED;
 
 	ServerConfigPacket config_packet;
 	config_packet.master_resource_key = master_resource_key_;
     config_packet.resources_loader_ui = resource_download_dialogs_.UsesClientLoader();
-	SendPacketToPlayer(session->playerid, PacketType::ServerConfig, config_packet);
+	SendPacketToSession(session, PacketType::ServerConfig, config_packet);
 
+	if (!IsSessionCurrent(session, epoch))
+	{
+		session->Reset();
+		return;
+	}
 	session->handshake_complete = true;
 
     NotifyCefInitialize(session, true, CEF_INIT_OK, "");
@@ -519,41 +589,121 @@ void CefPlugin::HandleKcpInput(std::shared_ptr<NetworkSession> session)
         }
     }
 
+    const int playerid = session->playerid;
+	const uint64_t epoch = session->epoch.load();
+	if (!IsSessionCurrent(session, epoch))
+		return;
+
     for (auto& packet : pendingPackets)
     {
-        switch (packet.type)
+        // File-transfer state belongs to the ASIO/KCP thread. Only its UI
+        // notification is marshalled by HandleFileRequest to the main thread.
+        if (packet.type == PacketType::RequestFiles)
         {
-            case PacketType::RequestFiles:
+			HandleFileRequest(session, epoch, std::get<RequestFilesPacket>(packet.payload));
+            continue;
+        }
+
+		EnqueueMainThreadTask([this, session, playerid, epoch, packet = std::move(packet)]() mutable
+        {
+			if (!running_ || !IsSessionCurrent(session, epoch))
+                return;
+
+            switch (packet.type)
             {
-                HandleFileRequest(session->playerid, std::get<RequestFilesPacket>(packet.payload));
-                break;
-            }
-            case PacketType::DownloadComplete:
-            {
-				NotifyCefReady(session);
-                break;
-            }
-            case PacketType::ClientEmitEvent:
-            {
-                if (auto* event = std::get_if<ClientEmitEventPacket>(&packet.payload)) {
-                    HandleClientEvent(session->playerid, *event);
+                case PacketType::DownloadComplete:
+                {
+					// This task is already running from the open.mp main-thread tick.
+					// Dispatch inline to preserve packet order and avoid a second queue hop.
+					DispatchCefReadyMainThread(session, epoch);
+                    break;
                 }
-                else {
-                    LOG_ERROR("ClientEmitEvent payload mismatch (variant index=%zu)", packet.payload.index());
+                case PacketType::ClientEmitEvent:
+                {
+                    if (auto* event = std::get_if<ClientEmitEventPacket>(&packet.payload)) {
+                        HandleClientEvent(playerid, *event);
+                    }
+                    else {
+                        LOG_ERROR("ClientEmitEvent payload mismatch (variant index=%zu)", packet.payload.index());
+                    }
+                    break;
                 }
-                break;
+                default:
+                    break;
             }
-            default:
-                break;
+        });
+    }
+}
+
+bool CefPlugin::IsSessionCurrent(const std::shared_ptr<NetworkSession>& session, uint64_t epoch) const
+{
+	if (!session || !sessions_ || session->epoch.load() != epoch)
+		return false;
+
+	return sessions_->GetSession(session->playerid) == session;
+}
+
+void CefPlugin::EnqueueMainThreadTask(std::function<void()> task)
+{
+    if (!task || !running_)
+        return;
+
+    std::lock_guard<std::mutex> lock(main_thread_tasks_mutex_);
+    if (!running_)
+        return;
+
+    // Bound the queue so a malformed or abusive client cannot exhaust server
+    // memory before the next open.mp tick drains it.
+    static constexpr size_t MaxPendingMainThreadTasks = 4096;
+    if (main_thread_tasks_.size() >= MaxPendingMainThreadTasks)
+    {
+        LOG_WARN("Dropping CEF main-thread task because the queue is full.");
+        return;
+    }
+
+    main_thread_tasks_.emplace_back(std::move(task));
+}
+
+void CefPlugin::ProcessMainThreadTasks()
+{
+    std::vector<std::function<void()>> tasks;
+    {
+        std::lock_guard<std::mutex> lock(main_thread_tasks_mutex_);
+        static constexpr size_t MaxTasksPerTick = 512;
+        const size_t count = std::min(MaxTasksPerTick, main_thread_tasks_.size());
+        tasks.reserve(count);
+        for (size_t i = 0; i < count; ++i)
+        {
+            tasks.emplace_back(std::move(main_thread_tasks_.front()));
+            main_thread_tasks_.pop_front();
+        }
+    }
+
+    for (auto& task : tasks)
+    {
+        if (!running_)
+            break;
+
+        try
+        {
+            task();
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("CEF main-thread task failed: %s", e.what());
+        }
+        catch (...)
+        {
+            LOG_ERROR("CEF main-thread task failed with an unknown exception.");
         }
     }
 }
 
-void CefPlugin::HandleFileRequest(int playerid, const RequestFilesPacket& request)
+void CefPlugin::HandleFileRequest(const std::shared_ptr<NetworkSession>& session, uint64_t epoch, const RequestFilesPacket& request)
 {
-	auto session = sessions_->GetSession(playerid);
-	if (!session)
+	if (!IsSessionCurrent(session, epoch))
 		return;
+	const int playerid = session->playerid;
 
 	std::vector<std::pair<std::string, size_t>> queuedFiles;
 	queuedFiles.reserve(request.files.size());
@@ -594,7 +744,11 @@ void CefPlugin::HandleFileRequest(int playerid, const RequestFilesPacket& reques
 	if (queuedFiles.empty() && !request.files.empty())
 		LOG_WARN("Resource download request from player %d did not match any registered resource file.", playerid);
 
-	resource_download_dialogs_.SetPlan(*bridge_, playerid, queuedFiles);
+	EnqueueMainThreadTask([this, session, playerid, epoch, queuedFiles = std::move(queuedFiles)]()
+	{
+		if (bridge_ && IsSessionCurrent(session, epoch))
+			resource_download_dialogs_.SetPlan(*bridge_, playerid, queuedFiles);
+	});
 }
 
 void CefPlugin::ProcessFileTransfers()
@@ -605,8 +759,16 @@ void CefPlugin::ProcessFileTransfers()
     auto all_sessions = sessions_->GetAllSessions();
     for (auto& session : all_sessions)
     {
-        if (!session || !session->kcp_instance || !session->handshake_complete)
+		if (!session || !session->handshake_complete)
             continue;
+		const uint64_t epoch = session->epoch.load();
+		if (!IsSessionCurrent(session, epoch))
+			continue;
+		{
+			std::lock_guard<std::mutex> guard(session->kcp_mutex);
+			if (!session->kcp_instance || session->handshake_status != HandshakeStatus::CONNECTED)
+				continue;
+		}
 
 		if (session->is_download_paused.load(std::memory_order_relaxed)) {
             continue;
@@ -619,12 +781,14 @@ void CefPlugin::ProcessFileTransfers()
 
             LOG_DEBUG("Starting transfer for player %d - file '%s'", session->playerid, session->current_transfer->relativePath.c_str());
 
-            resource_download_dialogs_.UpdateFileProgress(
-                *bridge_,
-                session->playerid,
-                session->current_transfer->relativePath,
-                0,
-                session->current_transfer->content.size());
+            const int playerid = session->playerid;
+            const std::string relativePath = session->current_transfer->relativePath;
+            const size_t totalBytes = session->current_transfer->content.size();
+			EnqueueMainThreadTask([this, session, playerid, epoch, relativePath, totalBytes]()
+            {
+				if (bridge_ && IsSessionCurrent(session, epoch))
+                    resource_download_dialogs_.UpdateFileProgress(*bridge_, playerid, relativePath, 0, totalBytes);
+            });
         }
 
         auto& transfer = session->current_transfer;
@@ -643,7 +807,13 @@ void CefPlugin::ProcessFileTransfers()
             {
                 LOG_DEBUG("Completed transfer for player %d - file '%s'", session->playerid, transfer->relativePath.c_str());
 
-                resource_download_dialogs_.CompleteCurrentFile(*bridge_, session->playerid, transfer->relativePath);
+                const int playerid = session->playerid;
+                const std::string relativePath = transfer->relativePath;
+				EnqueueMainThreadTask([this, session, playerid, epoch, relativePath]()
+                {
+					if (bridge_ && IsSessionCurrent(session, epoch))
+                        resource_download_dialogs_.CompleteCurrentFile(*bridge_, playerid, relativePath);
+                });
                 session->current_transfer = nullptr;
                 break;
             }
@@ -675,17 +845,25 @@ void CefPlugin::ProcessFileTransfers()
                 transfer->content.begin() + chunkOffset + chunkSize
             );
 
-            SendPacketToPlayer(session->playerid, PacketType::FileData, packet);
+			SendPacketToSession(session, PacketType::FileData, packet);
 
             ++transfer->currentChunkIndex;
             ++sent_this_tick;
+        }
 
-            resource_download_dialogs_.UpdateFileProgress(
-                *bridge_,
-                session->playerid,
-                transfer->relativePath,
-                std::min(static_cast<size_t>(transfer->currentChunkIndex) * FILE_CHUNK_SIZE, transfer->content.size()),
-                transfer->content.size());
+        // One progress notification per network tick is enough. Enqueuing one
+        // task per file chunk could otherwise overwhelm the main-thread queue.
+        if (transfer)
+        {
+            const int playerid = session->playerid;
+            const std::string relativePath = transfer->relativePath;
+            const size_t bytesSent = std::min(static_cast<size_t>(transfer->currentChunkIndex) * FILE_CHUNK_SIZE, transfer->content.size());
+            const size_t totalBytes = transfer->content.size();
+			EnqueueMainThreadTask([this, session, playerid, epoch, relativePath, bytesSent, totalBytes]()
+            {
+				if (bridge_ && IsSessionCurrent(session, epoch))
+                    resource_download_dialogs_.UpdateFileProgress(*bridge_, playerid, relativePath, bytesSent, totalBytes);
+            });
         }
     }
 }
@@ -708,21 +886,31 @@ void CefPlugin::SendPacketToPlayer(int playerid, PacketType type, const PacketPa
     if (!session)
         return;
 
+	SendPacketToSession(session, type, payload);
+}
+
+void CefPlugin::SendPacketToSession(const std::shared_ptr<NetworkSession>& session, PacketType type, const PacketPayload& payload)
+{
+	if (!session)
+		return;
+
     NetworkPacket packet{ type, payload };
 
     std::string raw_data;
     if (!SerializePacket(packet, raw_data)) {
-        LOG_ERROR("Failed to serialize packet (type %d) for player %d", (int)type, playerid);
+		LOG_ERROR("Failed to serialize packet (type %d) for player %d", (int)type, session->playerid);
         return;
     }
 
-    std::vector<uint8_t> encrypted = EncryptPacket({ raw_data.begin(), raw_data.end() }, session->tx_key);
-    if (encrypted.empty())
+    std::lock_guard<std::mutex> lock(session->kcp_mutex);
+	if (!session->kcp_instance || session->handshake_status != HandshakeStatus::CONNECTED)
         return;
 
-    std::lock_guard<std::mutex> lock(session->kcp_mutex);
-    if (!session->kcp_instance)
-        return;
+	// tx_key is replaced during transport reset, so encryption must be covered
+	// by the same mutex as the KCP instance.
+	std::vector<uint8_t> encrypted = EncryptPacket({ raw_data.begin(), raw_data.end() }, session->tx_key);
+	if (encrypted.empty())
+		return;
 
     ikcp_send(session->kcp_instance, (const char*)encrypted.data(), (int)encrypted.size());
 
@@ -735,21 +923,34 @@ void CefPlugin::NotifyCefInitialize(std::shared_ptr<NetworkSession> session, boo
 	if (!session || !bridge_)
 		return;
 
-	if (session->cef_init_notified)
-		return;
+	uint64_t epoch;
+	{
+		// Reset uses the same mutex, making the state transition and generation
+		// snapshot one indivisible transport operation.
+		std::lock_guard<std::mutex> lock(session->kcp_mutex);
+		epoch = session->epoch.load();
+		CefInitState expected = CefInitState::Pending;
+		const CefInitState desired = success ? CefInitState::Success : CefInitState::Failed;
+		if (!session->cef_init_state.compare_exchange_strong(expected, desired))
+			return;
+	}
 
-    session->cef_init_notified = true;
-    session->cef_success = success;
+    const int playerid = session->playerid;
+	EnqueueMainThreadTask([this, session, playerid, epoch, success, reason, message = std::move(message)]()
+    {
+		if (!bridge_ || !IsSessionCurrent(session, epoch))
+            return;
 
-    std::vector<Argument> args;
-    args.emplace_back(session->playerid);
-    args.emplace_back(success);
-    args.emplace_back(reason);
-    args.emplace_back(message);
-    bridge_->CallPawnPublic("OnCefInitialize", args);
+        std::vector<Argument> args;
+        args.emplace_back(playerid);
+        args.emplace_back(success);
+        args.emplace_back(reason);
+        args.emplace_back(message);
+        bridge_->CallPawnPublic("OnCefInitialize", args);
 
-    for (auto* h : GetCefEventHandlers())
-        h->onCefInitialize(session->playerid, success, reason, message.c_str());
+        for (auto* h : GetCefEventHandlers())
+            h->onCefInitialize(playerid, success, reason, message.c_str());
+    });
 }
 
 void CefPlugin::NotifyCefReady(std::shared_ptr<NetworkSession> session)
@@ -757,18 +958,32 @@ void CefPlugin::NotifyCefReady(std::shared_ptr<NetworkSession> session)
 	if (!session || !bridge_)
 		return;
 
-	if (!session->cef_init_notified)
+	if (session->cef_init_state.load() != CefInitState::Success)
 		return;
 
-    if (!session->cef_success)
+	const uint64_t epoch = session->epoch.load();
+	EnqueueMainThreadTask([this, session, epoch]()
+    {
+		DispatchCefReadyMainThread(session, epoch);
+    });
+}
+
+void CefPlugin::DispatchCefReadyMainThread(const std::shared_ptr<NetworkSession>& session, uint64_t epoch)
+{
+	if (!bridge_ || !IsSessionCurrent(session, epoch) || session->cef_init_state.load() != CefInitState::Success)
 		return;
 
-    std::vector<Argument> args;
-    args.emplace_back(session->playerid);
-    bridge_->CallPawnPublic("OnCefReady", args);
+	bool expected = false;
+	if (!session->cef_ready_notified.compare_exchange_strong(expected, true))
+		return;
 
-    for (auto* h : GetCefEventHandlers())
-        h->onCefReady(session->playerid);
+	const int playerid = session->playerid;
+	std::vector<Argument> args;
+	args.emplace_back(playerid);
+	bridge_->CallPawnPublic("OnCefReady", args);
+
+	for (auto* h : GetCefEventHandlers())
+		h->onCefReady(playerid);
 }
 
 void CefPlugin::BeginDownloadUi(int playerid)

--- a/src/server/common/plugin.hpp
+++ b/src/server/common/plugin.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <asio.hpp>
+#include <deque>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <shared/packet.hpp>
 #include <unordered_map>
+#include <vector>
 
 #include "api.hpp"
 #include "bridge.hpp"
@@ -54,11 +58,13 @@ public:
 	void OnPlayerDisconnect(int playerid);
 	bool OnDialogResponse(int playerid, int dialogid);
 	void SetSpawnScreenState(int playerid, bool visible);
+	void InvalidatePawnBridge();
 
 	void OnPacketReceived(const asio::ip::udp::endpoint& from, const char* data, int len);
 
-	void HandleFileRequest(int playerid, const RequestFilesPacket& request);
+	void HandleFileRequest(const std::shared_ptr<NetworkSession>& session, uint64_t epoch, const RequestFilesPacket& request);
 	void ProcessFileTransfers();
+	void ProcessMainThreadTasks();
 
 	void SendRawPacketToEndpoint(const asio::ip::udp::endpoint& endpoint, PacketType type, const PacketPayload& payload);
 	void SendPacketToPlayer(int playerid, PacketType type, const PacketPayload& payload);
@@ -84,6 +90,10 @@ private:
 	void HandleRequestJoin(const asio::ip::udp::endpoint& from, const RequestJoinPacket& packet);
 	void HandleHandshakeFinalize(const asio::ip::udp::endpoint& from, const HandshakeFinalizePacket& finalize_packet, std::shared_ptr<NetworkSession> session);
 	void HandleKcpInput(std::shared_ptr<NetworkSession> session);
+	void SendPacketToSession(const std::shared_ptr<NetworkSession>& session, PacketType type, const PacketPayload& payload);
+	void EnqueueMainThreadTask(std::function<void()> task);
+	bool IsSessionCurrent(const std::shared_ptr<NetworkSession>& session, uint64_t epoch) const;
+	void DispatchCefReadyMainThread(const std::shared_ptr<NetworkSession>& session, uint64_t epoch);
 
     void BeginDownloadUi(int playerid);
     void EndDownloadUi(int playerid);
@@ -111,6 +121,8 @@ private:
 	std::unique_ptr<NetworkServer> network_server_;
 	std::thread network_thread_;
 	std::atomic<bool> running_{ false };
+	std::mutex main_thread_tasks_mutex_;
+	std::deque<std::function<void()>> main_thread_tasks_;
 
 	std::unordered_map<std::string, RegisteredEvent> registered_events_;
 };

--- a/src/server/common/security.cpp
+++ b/src/server/common/security.cpp
@@ -64,7 +64,9 @@ bool SecurityManager::ValidateCookie(const asio::ip::udp::endpoint& client_endpo
         decrypted_cookie = DecryptCookie(cookie, cookie_secret_);
     }
 
-    if (decrypted_cookie.empty())
+	// Cookie plaintext is exactly IPv4 (4 bytes) + UDP port (2 bytes).
+	// Reject truncated/malformed client input before indexing it below.
+	if (decrypted_cookie.size() != 6)
         return false;
 
     try
@@ -99,6 +101,9 @@ std::vector<uint8_t> SecurityManager::InitiateKeyExchange(int playerid)
 std::unique_ptr<SessionKeys> SecurityManager::FinalizeKeyExchange(int playerid,
                                                                   const std::vector<uint8_t>& client_public_key)
 {
+	if (client_public_key.size() != crypto_kx_PUBLICKEYBYTES)
+		return nullptr;
+
     std::lock_guard<std::mutex> lock(kx_mutex_);
     auto it = pending_key_exchanges_.find(playerid);
     if (it == pending_key_exchanges_.end())

--- a/src/server/common/session.cpp
+++ b/src/server/common/session.cpp
@@ -18,9 +18,8 @@ void NetworkSession::ClearDownloadState()
 	is_download_paused.store(false);
 }
 
-void NetworkSession::ReleaseKcp()
+void NetworkSession::ReleaseKcpUnlocked()
 {
-	std::lock_guard<std::mutex> kcp_lock(kcp_mutex);
 	if (kcp_instance)
 	{
 		ikcp_release(kcp_instance);
@@ -28,16 +27,24 @@ void NetworkSession::ReleaseKcp()
 	}
 }
 
+NetworkSession::~NetworkSession()
+{
+	std::lock_guard<std::mutex> kcp_lock(kcp_mutex);
+	ReleaseKcpUnlocked();
+}
+
 void NetworkSession::Reset()
 {
-	ReleaseKcp();
+	std::lock_guard<std::mutex> kcp_lock(kcp_mutex);
+	ReleaseKcpUnlocked();
 
 	address = asio::ip::udp::endpoint{};
 	handshake_status = HandshakeStatus::NONE;
 	handshake_complete.store(false);
 	cef_init_timer_started.store(false);
-	cef_init_notified = false;
-	cef_success = false;
+	epoch.fetch_add(1);
+	cef_init_state.store(CefInitState::Pending);
+	cef_ready_notified.store(false);
 	rx_key.clear();
 	tx_key.clear();
 	chat_input_open = false;
@@ -56,7 +63,15 @@ void NetworkSessionManager::TrackClosedEndpoint(const asio::ip::udp::endpoint& a
 	if (addr.address().is_unspecified() || addr.port() == 0)
 		return;
 
-	closed_endpoint_expirations_[EndpointToStr(addr)] = std::chrono::steady_clock::now() + CLOSED_ENDPOINT_RETENTION;
+	TrackClosedEndpoint(EndpointToStr(addr));
+}
+
+void NetworkSessionManager::TrackClosedEndpoint(const std::string& endpointKey)
+{
+	if (endpointKey.empty())
+		return;
+
+	closed_endpoint_expirations_[endpointKey] = std::chrono::steady_clock::now() + CLOSED_ENDPOINT_RETENTION;
 }
 
 void NetworkSessionManager::RemoveExpiredClosedEndpoints()
@@ -72,69 +87,68 @@ void NetworkSessionManager::RemoveExpiredClosedEndpoints()
 	}
 }
 
-void NetworkSessionManager::RegisterPlayer(int playerid)
+void NetworkSessionManager::RegisterPlayer(int playerid, std::string officialIp)
 {
-	std::lock_guard<std::mutex> lock(mutex_);
-
-	std::shared_ptr<NetworkSession> session;
-
-	auto it = player_sessions_.find(playerid);
-	if (it == player_sessions_.end())
 	{
-		session = std::make_shared<NetworkSession>();
-		player_sessions_[playerid] = session;
-	}
-	else
-	{
-		session = it->second;
-		if (session->handshake_status != HandshakeStatus::NONE)
-			UnmapAddress(session->address);
-	}
+		std::lock_guard<std::mutex> lock(mutex_);
 
-	session->playerid = playerid;
-	session->send_fn = send_fn_;
-	session->Reset();
+		RemoveExpiredClosedEndpoints();
+		UnmapPlayer(playerid, true);
+
+		auto session = std::make_shared<NetworkSession>();
+		session->playerid = playerid;
+		session->official_ip = std::move(officialIp);
+		session->send_fn = send_fn_;
+		player_sessions_[playerid] = std::move(session);
+	}
 }
 
 void NetworkSessionManager::RemovePlayer(int playerid)
 {
-	std::lock_guard<std::mutex> lock(mutex_);
-
-	RemoveExpiredClosedEndpoints();
-
-	auto it = player_sessions_.find(playerid);
-	if (it != player_sessions_.end())
 	{
-		TrackClosedEndpoint(it->second->address);
+		std::shared_ptr<NetworkSession> removedSession;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
 
-		if (it->second->handshake_status != HandshakeStatus::NONE)
-			UnmapAddress(it->second->address);
+			RemoveExpiredClosedEndpoints();
+			UnmapPlayer(playerid, true);
 
-		it->second->Reset();
-		player_sessions_.erase(it);
+			auto it = player_sessions_.find(playerid);
+			if (it != player_sessions_.end())
+			{
+				removedSession = std::move(it->second);
+				player_sessions_.erase(it);
+			}
+		}
+
+		// Do not reset a session from the server thread. Any in-flight ASIO
+		// handler owns a shared_ptr and will release it on the network thread;
+		// otherwise destruction here is safe because nobody can be using it.
+		removedSession.reset();
 	}
 }
 
-void NetworkSessionManager::ResetPlayerTransport(int playerid)
+bool NetworkSessionManager::ResetPlayerTransport(int playerid, const std::shared_ptr<NetworkSession>& expectedSession)
 {
-	std::lock_guard<std::mutex> lock(mutex_);
+	std::shared_ptr<NetworkSession> session;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
 
-	RemoveExpiredClosedEndpoints();
+		RemoveExpiredClosedEndpoints();
 
-	auto it = player_sessions_.find(playerid);
-	if (it == player_sessions_.end() || !it->second)
-		return;
+		auto it = player_sessions_.find(playerid);
+		if (it == player_sessions_.end() || !it->second || it->second != expectedSession)
+			return false;
 
-	auto& session = *it->second;
+		UnmapPlayer(playerid, true);
+		session = it->second;
+	}
 
-	TrackClosedEndpoint(session.address);
-
-	if (session.handshake_status != HandshakeStatus::NONE)
-		UnmapAddress(session.address);
-
-	session.Reset();
-	session.playerid = playerid;
-	session.send_fn = send_fn_;
+	// This method is called by the single ASIO thread. Reset locks KCP against
+	// sends issued by Pawn on the main thread, while transfer state remains
+	// exclusively owned by ASIO.
+	session->Reset();
+	return true;
 }
 
 bool NetworkSessionManager::IsEndpointRecentlyClosed(const asio::ip::udp::endpoint& addr)
@@ -153,18 +167,7 @@ void NetworkSessionManager::ClearClosedEndpoint(const asio::ip::udp::endpoint& a
 
 void NetworkSessionManager::UpdateAllKcpInstances(uint32_t now_ms)
 {
-	std::vector<std::shared_ptr<NetworkSession>> sessions;
-
-	{
-		std::lock_guard<std::mutex> lock(mutex_);
-		sessions.reserve(player_sessions_.size());
-
-		for (auto& [playerid, session] : player_sessions_)
-		{
-			if (session && session->kcp_instance && session->handshake_status == HandshakeStatus::CONNECTED)
-				sessions.push_back(session);
-		}
-	}
+	auto sessions = GetAllSessions();
 
 	for (auto& session : sessions)
 	{
@@ -186,7 +189,6 @@ std::shared_ptr<NetworkSession> NetworkSessionManager::GetOrCreateSession(int pl
 
 		session->playerid = playerid;
 		session->send_fn = send_fn_;
-		session->Reset();
 
 		player_sessions_[playerid] = session;
 
@@ -256,14 +258,18 @@ bool NetworkSessionManager::HasPlayerPlugin(int playerid) const
 	return false;
 }
 
-void NetworkSessionManager::MapAddressToPlayer(int playerid, const asio::ip::udp::endpoint& addr)
+bool NetworkSessionManager::MapAddressToPlayer(int playerid, const std::shared_ptr<NetworkSession>& expectedSession, const asio::ip::udp::endpoint& addr)
 {
 	std::lock_guard<std::mutex> lock(mutex_);
+	auto it = player_sessions_.find(playerid);
+	if (it == player_sessions_.end() || !it->second || it->second != expectedSession)
+		return false;
 
 	RemoveExpiredClosedEndpoints();
 	closed_endpoint_expirations_.erase(EndpointToStr(addr));
 
 	addr_str_to_playerid_[EndpointToStr(addr)] = playerid;
+	return true;
 }
 
 void NetworkSessionManager::SetDownloadPaused(int playerid, bool paused)
@@ -279,6 +285,23 @@ void NetworkSessionManager::SetDownloadPaused(int playerid, bool paused)
 void NetworkSessionManager::UnmapAddress(const asio::ip::udp::endpoint& addr)
 {
 	addr_str_to_playerid_.erase(EndpointToStr(addr));
+}
+
+void NetworkSessionManager::UnmapPlayer(int playerid, bool trackAsClosed)
+{
+	for (auto it = addr_str_to_playerid_.begin(); it != addr_str_to_playerid_.end();)
+	{
+		if (it->second != playerid)
+		{
+			++it;
+			continue;
+		}
+
+		if (trackAsClosed)
+			TrackClosedEndpoint(it->first);
+
+		it = addr_str_to_playerid_.erase(it);
+	}
 }
 
 std::string NetworkSessionManager::EndpointToStr(const asio::ip::udp::endpoint& addr) const

--- a/src/server/common/session.hpp
+++ b/src/server/common/session.hpp
@@ -23,6 +23,13 @@ enum class HandshakeStatus : uint8_t
 	CONNECTED
 };
 
+enum class CefInitState : uint8_t
+{
+	Pending,
+	Success,
+	Failed
+};
+
 struct FileTransfer
 {
 	std::string resourceName;
@@ -36,14 +43,16 @@ struct FileTransfer
 struct NetworkSession
 {
 	int playerid = -1;
+	std::string official_ip;
 	asio::ip::udp::endpoint address;
 	ikcpcb* kcp_instance = nullptr;
 
 	HandshakeStatus handshake_status{HandshakeStatus::NONE};
 	std::atomic_bool handshake_complete{false};
 	std::atomic_bool cef_init_timer_started{false};
-	bool cef_init_notified{false};
-	bool cef_success{false};
+	std::atomic<CefInitState> cef_init_state{CefInitState::Pending};
+	std::atomic_bool cef_ready_notified{false};
+	std::atomic<uint64_t> epoch{1};
 
 	std::vector<uint8_t> rx_key;
 	std::vector<uint8_t> tx_key;
@@ -54,15 +63,16 @@ struct NetworkSession
 	std::shared_ptr<FileTransfer> current_transfer = nullptr;
 	std::atomic<bool> is_download_paused{false};
 
-	bool chat_input_open{false};
+	std::atomic_bool chat_input_open{false};
 
 	std::mutex kcp_mutex;
 
+	~NetworkSession();
 	void Reset();
 
 private:
 	void ClearDownloadState();
-	void ReleaseKcp();
+	void ReleaseKcpUnlocked();
 };
 
 class NetworkSessionManager
@@ -74,9 +84,9 @@ public:
 	NetworkSessionManager& operator=(const NetworkSessionManager&) = delete;
 
 	void SetSender(std::function<void(const asio::ip::udp::endpoint&, const char*, int)> fn);
-	void RegisterPlayer(int playerid);
+	void RegisterPlayer(int playerid, std::string officialIp);
 	void RemovePlayer(int playerid);
-	void ResetPlayerTransport(int playerid);
+	bool ResetPlayerTransport(int playerid, const std::shared_ptr<NetworkSession>& expectedSession);
 
 	bool IsEndpointRecentlyClosed(const asio::ip::udp::endpoint& addr);
 	void ClearClosedEndpoint(const asio::ip::udp::endpoint& addr);
@@ -87,16 +97,18 @@ public:
 	std::shared_ptr<NetworkSession> GetSession(int playerid);
 	std::vector<std::shared_ptr<NetworkSession>> GetAllSessions();
 	bool HasPlayerPlugin(int playerid) const;
-	void MapAddressToPlayer(int playerid, const asio::ip::udp::endpoint& addr);
+	bool MapAddressToPlayer(int playerid, const std::shared_ptr<NetworkSession>& expectedSession, const asio::ip::udp::endpoint& addr);
 	void SetDownloadPaused(int playerid, bool paused);
 
 private:
 	static constexpr std::chrono::milliseconds CLOSED_ENDPOINT_RETENTION{3000};
 
 	void TrackClosedEndpoint(const asio::ip::udp::endpoint& addr);
+	void TrackClosedEndpoint(const std::string& endpointKey);
 	void RemoveExpiredClosedEndpoints();
 
 	void UnmapAddress(const asio::ip::udp::endpoint& addr);
+	void UnmapPlayer(int playerid, bool trackAsClosed);
 	std::string EndpointToStr(const asio::ip::udp::endpoint& addr) const;
 
 	mutable std::mutex mutex_;

--- a/src/server/omp/component.cpp
+++ b/src/server/omp/component.cpp
@@ -56,6 +56,7 @@ SemanticVersion CefOmpComponent::componentVersion() const
 void CefOmpComponent::onLoad(ICore* core)
 {
     core_ = core;
+	core_->getEventDispatcher().addEventHandler(this);
     core_->getPlayers().getPlayerConnectDispatcher().addEventHandler(this);
     setAmxLookups(core_);
 }
@@ -90,6 +91,10 @@ void CefOmpComponent::onFree(IComponent* component)
 {
     if (component == pawn_)
     {
+		if (plugin_)
+		{
+			plugin_->InvalidatePawnBridge();
+		}
         pawn_ = nullptr;
     }
 }
@@ -176,6 +181,17 @@ void CefOmpComponent::onAmxUnload(IPawnScript& script)
 
 }
 
+void CefOmpComponent::onTick(Microseconds elapsed, TimePoint now)
+{
+    (void)elapsed;
+    (void)now;
+
+    if (plugin_)
+    {
+        plugin_->ProcessMainThreadTasks();
+    }
+}
+
 void CefOmpComponent::onPlayerConnect(IPlayer& player)
 {
     plugin_->OnPlayerConnect(player.getID());
@@ -200,6 +216,7 @@ CefOmpComponent::~CefOmpComponent()
 
     if (core_)
     {
+		core_->getEventDispatcher().removeEventHandler(this);
         core_->getPlayers().getPlayerConnectDispatcher().removeEventHandler(this);
     }
 }

--- a/src/server/omp/component.hpp
+++ b/src/server/omp/component.hpp
@@ -10,6 +10,7 @@ struct ICefOmpComponent : IComponent
 
 class CefOmpComponent final : public ICefOmpComponent,
                               public PawnEventHandler,
+                              public CoreEventHandler,
                               public PlayerConnectEventHandler
 {
 public:
@@ -30,6 +31,7 @@ public:
 
     void onAmxLoad(IPawnScript& script) override;
     void onAmxUnload(IPawnScript& script) override;
+	void onTick(Microseconds elapsed, TimePoint now) override;
 
     void onPlayerConnect(IPlayer& player) override;
     void onPlayerClientInit(IPlayer& player) override;
@@ -39,8 +41,8 @@ private:
     static constexpr uint16_t cef_network_port_offset = 2;
 
 private:
-    ICore* core_ = nullptr;
-    IPawnComponent* pawn_;
+	ICore* core_ = nullptr;
+	IPawnComponent* pawn_ = nullptr;
 
     std::unique_ptr<CefPlugin> plugin_;
 

--- a/src/server/omp/omg_bridge.cpp
+++ b/src/server/omp/omg_bridge.cpp
@@ -276,5 +276,10 @@ bool OmpPlatformBridge::IsPlayerNpcBot(int playerid)
     if (!player)
         return false;
 
-    return player->isBot();
+	return player->isBot();
+}
+
+void OmpPlatformBridge::InvalidatePawn()
+{
+	pawn_ = nullptr;
 }

--- a/src/server/omp/omp_bridge.hpp
+++ b/src/server/omp/omp_bridge.hpp
@@ -42,6 +42,7 @@ public:
     std::string GetPlayerAddressIp(int playerid) override;
     void KickPlayer(int playerid) override;
     bool IsPlayerNpcBot(int playerid) override;
+	void InvalidatePawn() override;
 
 private:
     ICore* core_;


### PR DESCRIPTION
## Summary

This pull request extends the plugin's native CEF input support and improves server-side thread safety.

## Changes

### Drag-and-drop support

- Implements native drag-and-drop for windowless CEF browsers.
- Forwards drag enter, drag over, drop and drag leave events.
- Dispatches drag operations on the CEF UI thread.
- Updates the native cursor according to the active drag operation.

### Double-click support

- Implements native double-click detection using the operating system's configured interval and cursor distance.
- Handles native `WM_*BUTTONDBLCLK` messages.
- Forwards the correct click count to CEF.
- Adds middle mouse button handling.
- Improves mouse modifier and wheel event forwarding.

### Server thread safety

- Dispatches CEF callbacks and Pawn interactions on the server's main thread.
- Improves synchronization around sessions, callbacks and plugin lifecycle operations.
- Prevents worker threads from directly accessing APIs that require the main server thread.
- Improves cleanup behavior during session disconnection and plugin shutdown.
- Reduces the risk of race conditions, invalid memory access and intermittent crashes.

## Validation

- Client compiled successfully in Release Win32.
- Server component compiled successfully for x86.
- Drag-and-drop and double-click events were verified in CEF browser interfaces.
- Server callback paths were reviewed to ensure main-thread-only APIs are dispatched correctly.